### PR TITLE
Alteração da propriedade HTTPConstants.CHUNKED para false no WebService de Consulta de MDFe Nao Encerrados

### DIFF
--- a/src/main/java/com/fincatto/documentofiscal/mdfe3/webservices/consultanaoencerrado/MDFeConsNaoEncStub.java
+++ b/src/main/java/com/fincatto/documentofiscal/mdfe3/webservices/consultanaoencerrado/MDFeConsNaoEncStub.java
@@ -7,6 +7,7 @@ import javax.xml.namespace.QName;
 
 import org.apache.axiom.om.OMAttribute;
 import org.apache.axis2.client.Stub;
+import org.apache.axis2.transport.http.HTTPConstants;
 
 import com.fincatto.documentofiscal.DFConfig;
 import com.fincatto.documentofiscal.utils.MessageContextFactory;
@@ -72,6 +73,7 @@ public class MDFeConsNaoEncStub extends org.apache.axis2.client.Stub {
         this._serviceClient = new org.apache.axis2.client.ServiceClient(configurationContext, this._service);
         this._serviceClient.getOptions().setTo(new org.apache.axis2.addressing.EndpointReference(targetEndpoint));
         this._serviceClient.getOptions().setUseSeparateListener(useSeparateListener);
+        this._serviceClient.getOptions().setProperty(HTTPConstants.CHUNKED, false);
         // Set the soap version
         this._serviceClient.getOptions().setSoapVersionURI(org.apache.axiom.soap.SOAP12Constants.SOAP_ENVELOPE_NAMESPACE_URI);
         this.config = config;


### PR DESCRIPTION
Alteração realizada no construtor da classe MDFeConsNaoEncStub.
"this._serviceClient.getOptions().setProperty(HTTPConstants.CHUNKED, false);"